### PR TITLE
fix(libuzfs): use correct directory to build libuzfs

### DIFF
--- a/uzfs-sys/Cargo.toml
+++ b/uzfs-sys/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 pkg-config = "0.3"
 build-env = "0.3"
 bindgen = "0.60"
-project-root = "0.2"
 
 [dependencies]
 libc = "0.2"

--- a/uzfs-sys/build.rs
+++ b/uzfs-sys/build.rs
@@ -1,7 +1,7 @@
-use std::{env, process::Command};
+use std::{env, fs, process::Command};
 
 fn main() {
-    let root = project_root::get_project_root().unwrap();
+    let root = fs::canonicalize("..").unwrap();
     Command::new("make")
         .args(&["-C", root.to_str().unwrap(), "build_libuzfs_src"])
         .status()

--- a/uzfs/Cargo.toml
+++ b/uzfs/Cargo.toml
@@ -7,7 +7,6 @@ links = "uzfs"
 [build-dependencies]
 pkg-config = "0.3"
 build-env = "0.3"
-project-root = "0.2"
 uzfs-sys = { path = "../uzfs-sys", version = "0.1.0" }
 
 [dependencies]

--- a/uzfs/build.rs
+++ b/uzfs/build.rs
@@ -1,7 +1,7 @@
-use std::env;
+use std::{env, fs};
 
 fn main() {
-    let root = project_root::get_project_root().unwrap();
+    let root = fs::canonicalize("..").unwrap();
     env::set_var("PKG_CONFIG_PATH", root);
     let mut lib = pkg_config::probe_library("libuzfs").unwrap();
     let link = lib.link_paths.pop().unwrap();


### PR DESCRIPTION
project_root searches closest directory containing Cargo.lock as root directory, but when building from external application or library, the Cargo.lock will not generated in libuzfs-rs, causing unwrap error.

Signed-off-by: Ping Huang <huangping@smartx.com>