### PR TITLE
build(uzfs-sys): avoid build script always re-run in cargo build

### DIFF
--- a/uzfs-sys/build.rs
+++ b/uzfs-sys/build.rs
@@ -2,7 +2,6 @@ use std::{env, fs, process::Command};
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rerun-if-changed=src/buildings.rs");
     println!("cargo:rerun-if-changed=src/wrapper.h");
     println!("cargo:rerun-if-changed=zfs");
 


### PR DESCRIPTION
bindings.rs is generated when build script runs, cargo compares its mtime with output file's mtime to determine if the build script needs to re-run. While output file's mtime is always 1-2s smaller than bindings.rs mtime, this satisfies the re-run condition.