### PR TITLE
fix(libuzfs): adjust claim related interfaces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ tempfile = "3.3.0"
 
 [dev-dependencies]
 criterion = "0.3"
+env_logger="0.9.0"
+test-log = "0.2.8"
+serial_test = { version = "1.0.0" }
 
 [[bench]]
 name = "uzfs-bench"

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ test:
 
 clean:
 	cargo clean
+	make -C uzfs-sys clean
 
 bench:
 	cargo bench --all

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,16 +191,6 @@ impl Dataset {
         }
     }
 
-    pub fn claim_object(&self, obj: u64) -> Result<()> {
-        let err = unsafe { sys::libuzfs_object_claim(self.dhp, obj) };
-
-        if err == 0 {
-            Ok(())
-        } else {
-            Err(io::Error::from_raw_os_error(err))
-        }
-    }
-
     pub fn delete_object(&self, obj: u64) -> Result<()> {
         let err = unsafe { sys::libuzfs_object_delete(self.dhp, obj) };
 
@@ -816,11 +806,6 @@ mod tests {
             assert!(ds.get_last_synced_txg().unwrap() >= txg);
 
             assert_eq!(ds.list_object().unwrap(), num);
-
-            ds.claim_object(rwobj).unwrap();
-            ds.wait_synced().unwrap();
-
-            assert_eq!(ds.list_object().unwrap(), num + 1);
         }
 
         {

--- a/uzfs-sys/scripts/build_libuzfs_src.sh
+++ b/uzfs-sys/scripts/build_libuzfs_src.sh
@@ -35,7 +35,7 @@ unzip_src() {
 
 build_libuzfs_lib() {
     cd ${ZFS_DIR}
-    ./autogen.sh && CFLAGS=-fPIC ./configure --with-config=user --enable-shared=no --prefix=${INSTALL_DIR} && make gitrev
+    ./autogen.sh && CFLAGS=-fPIC ./configure --with-config=user --enable-shared=no --enable-debuginfo=yes --prefix=${INSTALL_DIR} && make gitrev
     cd lib
     make -j4 && make install
     cd ../include


### PR DESCRIPTION
1. fix(libuzfs): remove object claim interface
2. test(libuzfs): add inode claim test
3. build(uzfs-sys): enable debuginfo by default
4. build(uzfs): make clean also cleanup uzfs-sys