### PR TITLE
feat(dataset): add ha_disk and dentry prefetch support

### DIFF
--- a/src/bin/bench/main.rs
+++ b/src/bin/bench/main.rs
@@ -68,7 +68,7 @@ async fn main() {
     let file_size = 1 << 30;
 
     let ds = Arc::new(
-        Dataset::init("testzp/ds", &dev_path, DatasetType::Data, 0, false)
+        Dataset::init("testzp/ds", &dev_path, DatasetType::Data, 0, false, false)
             .await
             .unwrap(),
     );

--- a/src/bindings/async_sys.rs
+++ b/src/bindings/async_sys.rs
@@ -181,6 +181,7 @@ pub struct LibuzfsDatasetInitArg {
     pub already_formatted: bool,
     pub metrics: *const c_void,
     pub enable_autotrim: bool,
+    pub ha_disk: bool,
 
     pub ret: i32,
     pub dhp: *mut libuzfs_dataset_handle_t,
@@ -221,7 +222,12 @@ pub unsafe extern "C" fn libuzfs_dataset_init_c(arg: *mut c_void) {
         return;
     }
 
-    arg.zhp = libuzfs_zpool_open(arg.pool_name, &mut arg.ret, arg.enable_autotrim as u32);
+    arg.zhp = libuzfs_zpool_open(
+        arg.pool_name,
+        &mut arg.ret,
+        arg.enable_autotrim as u32,
+        arg.ha_disk as _,
+    );
     if !arg.zhp.is_null() {
         assert_eq!(arg.ret, 0);
         arg.dhp = libuzfs_dataset_open(
@@ -970,6 +976,8 @@ pub struct LibuzfsIterateDentryArg {
     pub dihp: *mut libuzfs_inode_handle_t,
     pub whence: u64,
     pub size: u32,
+    pub mask: u64,
+    pub prefetch: bool,
 
     pub err: i32,
     pub done: bool,
@@ -1012,7 +1020,14 @@ pub unsafe extern "C" fn libuzfs_iterate_dentry_c(arg: *mut c_void) {
 
     arg.dentries.reserve(DEFAULT_NDENTRIES);
 
-    arg.err = libuzfs_dentry_iterate(arg.dihp, arg.whence, arg_ptr, Some(dir_emit));
+    arg.err = libuzfs_dentry_iterate(
+        arg.dihp,
+        arg.whence,
+        arg_ptr,
+        Some(dir_emit),
+        arg.prefetch as _,
+        arg.mask,
+    );
 
     if arg.err == libc::ENOENT {
         arg.done = true;

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -303,6 +303,7 @@ impl Dataset {
         dstype: DatasetType,
         max_blksize: u32,
         already_formatted: bool,
+        ha_disk: bool,
     ) -> Result<Self> {
         assert!(max_blksize == 0 || (max_blksize & (max_blksize - 1)) == 0);
 
@@ -327,6 +328,7 @@ impl Dataset {
             already_formatted,
             metrics: metrics.as_ref() as *const _ as *const _,
             enable_autotrim,
+            ha_disk,
 
             ret: 0,
             dhp: std::ptr::null_mut(),
@@ -1256,12 +1258,16 @@ impl Dataset {
         ino_hdl: &InodeHandle,
         whence: u64,
         size: u32,
+        mask: u64,
+        prefetch: bool,
     ) -> Result<(Vec<UzfsDentry>, bool)> {
         let _guard = self.metrics.record(RequestMethod::IterateDentry, 0);
         let mut arg = LibuzfsIterateDentryArg {
             dihp: ino_hdl.ihp,
             whence,
             size,
+            mask,
+            prefetch,
             err: 0,
             dentries: Vec::new(),
             done: false,

--- a/src/tests/dataset_tests.rs
+++ b/src/tests/dataset_tests.rs
@@ -58,6 +58,7 @@ async fn uzfs_test() {
             DatasetType::Meta,
             4096,
             false,
+            false,
         )
         .await
         .unwrap()
@@ -72,6 +73,7 @@ async fn uzfs_test() {
                 DatasetType::Meta,
                 4096,
                 false,
+                false,
             )
             .await
             .unwrap()
@@ -85,6 +87,7 @@ async fn uzfs_test() {
             uzfs_test_env.get_dev_path(),
             DatasetType::Meta,
             0,
+            false,
             false,
         )
         .await
@@ -187,7 +190,10 @@ async fn uzfs_test() {
         ds.wait_synced().await;
         assert!(ds.get_last_synced_txg() >= txg);
 
-        let (dentries, done) = ds.iterate_dentry(&dir_hdl, 0, 4096).await.unwrap();
+        let (dentries, done) = ds
+            .iterate_dentry(&dir_hdl, 0, 4096, u64::MAX, false)
+            .await
+            .unwrap();
 
         // TODO(hping): verify dentry content
         assert_eq!(dentries.len(), 1);
@@ -249,6 +255,7 @@ async fn uzfs_test() {
             DatasetType::Meta,
             4096,
             false,
+            false,
         )
         .await
         .unwrap();
@@ -285,13 +292,19 @@ async fn uzfs_test() {
         let dentry_data_read = ds.lookup_dentry(&dir_hdl, file_name).await.unwrap();
         assert_eq!(file_ino, dentry_data_read);
 
-        let (detries, done) = ds.iterate_dentry(&dir_hdl, 0, 4096).await.unwrap();
+        let (detries, done) = ds
+            .iterate_dentry(&dir_hdl, 0, 4096, u64::MAX, false)
+            .await
+            .unwrap();
         assert_eq!(detries.len(), 1);
         assert!(done);
 
         _ = ds.delete_dentry(&mut dir_hdl, file_name).await.unwrap();
 
-        let (detries, done) = ds.iterate_dentry(&dir_hdl, 0, 4096).await.unwrap();
+        let (detries, done) = ds
+            .iterate_dentry(&dir_hdl, 0, 4096, u64::MAX, false)
+            .await
+            .unwrap();
         assert_eq!(detries.len(), 0);
         assert!(done);
 
@@ -329,6 +342,7 @@ async fn uzfs_test() {
             uzfs_test_env.get_dev_path(),
             DatasetType::Meta,
             4096,
+            false,
             false,
         )
         .await
@@ -391,6 +405,7 @@ async fn uzfs_claim_test() {
             DatasetType::Meta,
             4096,
             false,
+            false,
         )
         .await
         .unwrap();
@@ -432,6 +447,7 @@ async fn uzfs_claim_test() {
             DatasetType::Meta,
             4096,
             false,
+            false,
         )
         .await
         .unwrap();
@@ -449,6 +465,7 @@ async fn uzfs_claim_test() {
             uzfs_test_env.get_dev_path(),
             DatasetType::Meta,
             4096,
+            false,
             false,
         )
         .await
@@ -483,6 +500,7 @@ async fn uzfs_zap_iterator_test() {
             uzfs_test_env.get_dev_path(),
             DatasetType::Meta,
             4096,
+            false,
             false,
         )
         .await
@@ -542,6 +560,7 @@ async fn uzfs_expand_test() {
             uzfs_test_env.get_dev_path(),
             DatasetType::Data,
             4096,
+            false,
             false,
         )
         .await
@@ -609,6 +628,7 @@ async fn uzfs_rangelock_test() {
             uzfs_test_env.get_dev_path(),
             DatasetType::Data,
             4096,
+            false,
             false,
         )
         .await
@@ -729,6 +749,7 @@ async fn uzfs_attr_test() {
             uzfs_test_env.get_dev_path(),
             DatasetType::Meta,
             4096,
+            false,
             false,
         )
         .await
@@ -876,7 +897,7 @@ async fn uzfs_attr_test() {
 }
 
 async fn test_reduce_max(dsname: &str, dev_path: &str) {
-    let ds = Dataset::init(dsname, dev_path, DatasetType::Data, 4096, false)
+    let ds = Dataset::init(dsname, dev_path, DatasetType::Data, 4096, false, false)
         .await
         .unwrap();
     let (objs, gen) = ds.create_objects(4).await.unwrap();
@@ -922,7 +943,7 @@ async fn test_reduce_max(dsname: &str, dev_path: &str) {
     ds.release_inode_handle(&mut hdl3).await;
     ds.close().await.unwrap();
 
-    let ds = Dataset::init(dsname, dev_path, DatasetType::Data, 1024, false)
+    let ds = Dataset::init(dsname, dev_path, DatasetType::Data, 1024, false, false)
         .await
         .unwrap();
     let mut hdl0 = ds.get_inode_handle(objs[0], gen, true).await.unwrap();
@@ -953,7 +974,7 @@ async fn test_reduce_max(dsname: &str, dev_path: &str) {
 }
 
 async fn test_increase_max(dsname: &str, dev_path: &str) {
-    let ds = Dataset::init(dsname, dev_path, DatasetType::Data, 1024, false)
+    let ds = Dataset::init(dsname, dev_path, DatasetType::Data, 1024, false, false)
         .await
         .unwrap();
     let (objs, gen) = ds.create_objects(3).await.unwrap();
@@ -984,7 +1005,7 @@ async fn test_increase_max(dsname: &str, dev_path: &str) {
     ds.release_inode_handle(&mut hdl2).await;
     ds.close().await.unwrap();
 
-    let ds = Dataset::init(dsname, dev_path, DatasetType::Data, 4096, false)
+    let ds = Dataset::init(dsname, dev_path, DatasetType::Data, 4096, false, false)
         .await
         .unwrap();
     let mut hdl0 = ds.get_inode_handle(objs[0], gen, true).await.unwrap();
@@ -1080,7 +1101,7 @@ fn uzfs_sync_test() {
                     }
                     uzfs_env_init().await;
                     let ds = Arc::new(
-                        Dataset::init(dsname, dev_path, DatasetType::Data, 262144, false)
+                        Dataset::init(dsname, dev_path, DatasetType::Data, 262144, false, false)
                             .await
                             .unwrap(),
                     );
@@ -1186,6 +1207,7 @@ async fn uzfs_write_read_test() {
             DatasetType::Data,
             65536,
             false,
+            false,
         )
         .await
         .unwrap(),
@@ -1238,6 +1260,7 @@ async fn uzfs_truncate_test() {
             uzfs_test_env.get_dev_path(),
             DatasetType::Data,
             blksize,
+            false,
             false,
         )
         .await
@@ -1331,6 +1354,7 @@ async fn next_block_test() {
         DatasetType::Data,
         0,
         false,
+        false,
     )
     .await
     .unwrap();
@@ -1375,6 +1399,7 @@ async fn dentry_test() {
         DatasetType::Meta,
         0,
         false,
+        false,
     )
     .await
     .unwrap();
@@ -1402,7 +1427,10 @@ async fn dentry_test() {
                 .unwrap();
         }
 
-        let (dentries, done) = ds.iterate_dentry(&ino_hdl, 0, 1 << 20).await.unwrap();
+        let (dentries, done) = ds
+            .iterate_dentry(&ino_hdl, 0, 1 << 20, u64::MAX, false)
+            .await
+            .unwrap();
         assert!(done);
         assert_eq!(dentries.len(), ndentries as usize);
         verify_dentries(dentries);
@@ -1410,7 +1438,10 @@ async fn dentry_test() {
         let mut dentries = Vec::new();
         let mut whence = 0;
         loop {
-            let (dentries_part, done) = ds.iterate_dentry(&ino_hdl, whence, 1 << 9).await.unwrap();
+            let (dentries_part, done) = ds
+                .iterate_dentry(&ino_hdl, whence, 1 << 9, u64::MAX, false)
+                .await
+                .unwrap();
             dentries.extend(dentries_part);
             whence = dentries.last().unwrap().whence;
             if done {
@@ -1438,6 +1469,7 @@ async fn read_zero_copy_test() {
             uzfs_test_env.get_dev_path(),
             DatasetType::Data,
             0,
+            false,
             false,
         )
         .await


### PR DESCRIPTION
Add ha_disk parameter to Dataset::init for HA disk configuration. Add mask and prefetch parameters to iterate_dentry for selective dentry iteration and prefetching optimization.